### PR TITLE
Add Fanout label to :dependabot: PR's

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+      - dependencies
+      - ruby
+      - Fanout


### PR DESCRIPTION
Add `Fanout` label for internal routing of :dependabot: PR's across our project boards.