### PR TITLE
Have :dependabot: watch github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
We've got several very outdated actions in the workflows within this repo... 

https://github.com/dependabot/dependabot-actions-workflow/blob/01334a3b5c4eb889fd078cb9d120bb0b37b105ca/.github/workflows/update_dependabot_bundler_pr.yml#L23

The latest release is `v6.4.1` 🤦‍♂️ 

So let's get :dependabot: on the case! 🕵️