### PR TITLE
Stop pinning to old `ruby` version

### DIFF
--- a/.github/workflows/build_dependabot_bundler_pr.yml
+++ b/.github/workflows/build_dependabot_bundler_pr.yml
@@ -21,9 +21,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby
-        uses: ruby/setup-ruby@fdcfbcf14ec9672f6f615cb9589a1bc5dd69d262
+        uses: ruby/setup-ruby@904f3fef85a9c80a3750cbe7d5159268fd5caa9f # v1.145.0
         with:
-          ruby-version: 2.7
+          ruby-version: ruby
       - run: bundle install
       - run: mkdir ./dependabot-pr
       - name: Save branch ref


### PR DESCRIPTION
No need to pin to outdated `ruby` version in this action