### PR TITLE
Elevate perms of `GITHUB_TOKEN` to `write`

### DIFF
--- a/.github/workflows/update_dependabot_bundler_pr.yml
+++ b/.github/workflows/update_dependabot_bundler_pr.yml
@@ -18,6 +18,8 @@ jobs:
     if: >
       ${{ github.event.workflow_run.event == 'push' &&
       github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      contents: write
     steps:
       - name: Download pr changes
         uses: actions/github-script@v3.1.0


### PR DESCRIPTION
I changed the default repo/org permissions of the `GITHUB_TOKEN` to match the new default: https://github.blog/changelog/2023-02-02-github-actions-updating-the-default-github_token-permissions-to-read-only/

But this workflow requires a `contents: write` permission in order to commit back to the PR branch.

So elevate it.

This way our examples are more useful going forward for anyone creating a new repo.