### PR TITLE
Use Bundler 2 since Bundler 1 isn't Ruby 3.2 compatible

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,4 +58,4 @@ DEPENDENCIES
   licensed (= 4.3.0)
 
 BUNDLED WITH
-   1.17.3
+   2.4.13


### PR DESCRIPTION
In https://github.com/dependabot/dependabot-actions-workflow/pull/73, I switched to using the default `ruby`, which is `3.2.x` currently.

But that dropped support for Bundler 1... so regenerated the lockfile with:
```bash
bundle update --bundler
```

in a codespace running Ruby 3.1.4.